### PR TITLE
fix(kleinanzeigen): bump supported version to 2026.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.3.2](https://github.com/docbt/patched-up/compare/v1.3.1...v1.3.2) (2026-03-27)
+
+
+### Bug Fixes
+
+* **kleinanzeigen:** bump supported version to 2026.13.2
+
 ## [1.3.1](https://github.com/docbt/patched-up/compare/v1.3.0...v1.3.1) (2026-03-21)
 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.parallel = true
 org.gradle.caching = true
 kotlin.code.style = official
-version = 1.3.1
+version = 1.3.2

--- a/patches-list.json
+++ b/patches-list.json
@@ -87,7 +87,7 @@
       "dependencies": [],
       "compatiblePackages": {
         "com.ebay.kleinanzeigen": [
-          "2026.12.0"
+          "2026.13.2"
         ]
       },
       "options": []

--- a/patches/src/main/kotlin/app/docbt/patched_up/kleinanzeigen/ads/HideAdsPatch.kt
+++ b/patches/src/main/kotlin/app/docbt/patched_up/kleinanzeigen/ads/HideAdsPatch.kt
@@ -8,7 +8,7 @@ val hideAdsPatch = bytecodePatch(
     name = "Hide ads",
     description = "Hides sponsored ads and Google Ads. Also disables Microsoft Clarity analytics.",
 ) {
-    compatibleWith("com.ebay.kleinanzeigen" to setOf("2026.12.0"))
+    compatibleWith("com.ebay.kleinanzeigen" to setOf("2026.13.2"))
 
     execute {
         // Liberty init method initializes the ad/analytics SDK.

--- a/patches/src/main/kotlin/app/docbt/patched_up/kleinanzeigen/hidepur/HidePurPatch.kt
+++ b/patches/src/main/kotlin/app/docbt/patched_up/kleinanzeigen/hidepur/HidePurPatch.kt
@@ -10,7 +10,7 @@ val hidePurPatch = bytecodePatch(
     name = "Hide Pur",
     description = "Hides the Pur ad-free subscription option from the settings menu.",
 ) {
-    compatibleWith("com.ebay.kleinanzeigen" to setOf("2026.12.0"))
+    compatibleWith("com.ebay.kleinanzeigen" to setOf("2026.13.2"))
 
     execute {
         with(InstructionExtensions) {


### PR DESCRIPTION
Bumps the supported Kleinanzeigen version to 2026.13.2 and releases v1.3.2.

- `HideAdsPatch`: 2026.12.0 → 2026.13.2
- `HidePurPatch`: 2026.12.0 → 2026.13.2
- `patches-list.json`: version updated accordingly
- `gradle.properties`: 1.3.1 → 1.3.2
- `CHANGELOG.md`: entry for 1.3.2 added

Please merge as **squash merge**.