### PR TITLE
feat(kleinanzeigen): remove UTM tracking params from share URLs

### DIFF
--- a/.github/workflows/build_dev.yml
+++ b/.github/workflows/build_dev.yml
@@ -1,0 +1,35 @@
+name: Build dev
+
+on:
+  push:
+    branches:
+      - dev
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Cache Gradle
+        uses: burrunan/gradle-cache-action@v3
+
+      - name: Build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew :patches:buildAndroid --no-daemon
+
+      - name: Upload patch artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: patches-dev
+          path: patches/build/libs/patches-*.mpp
+          retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - dev
 
 jobs:
   release:

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 [![Gradle](https://img.shields.io/badge/Gradle-8.x-02303A?style=flat-square&logo=gradle)](https://gradle.org)
 [![Patches](https://img.shields.io/badge/Patches-2%20Apps-success?style=flat-square)](#supported-apps--patches)
 
+
 [![Buy Me A Coffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-ffdd00?style=flat-square&logo=buy-me-a-coffee&logoColor=black)](https://buymeacoffee.com/docbt)
 
 </div>
@@ -27,7 +28,7 @@ The goal of this project is to migrate missing ReVanced patches to Morphe and ke
 | App | Package | Version | Patches |
 |---|---|---|---|
 | Google News 🎯🌎 | `com.google.android.apps.magazines` | [![Google News](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdocbt%2Fpatched-up%2Fmain%2Fversions.json&query=%24.googleNews&label=&color=blue&style=flat-square)](versions.json) | Custom Tabs, GMS Support |
-| Kleinanzeigen 🎯 | `com.ebay.kleinanzeigen` | [![Kleinanzeigen](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdocbt%2Fpatched-up%2Fmain%2Fversions.json&query=%24.kleinanzeigen&label=&color=blue&style=flat-square)](versions.json) | Hide Ads, Hide Pur |
+| Kleinanzeigen 🎯 | `com.ebay.kleinanzeigen` | [![Kleinanzeigen](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdocbt%2Fpatched-up%2Fmain%2Fversions.json&query=%24.kleinanzeigen&label=&color=blue&style=flat-square)](versions.json) | Hide Ads, Hide Pur, Remove Tracking Params |
 
 > 🌎 Supports MicroG integration.
 >
@@ -49,6 +50,7 @@ The goal of this project is to migrate missing ReVanced patches to Morphe and ke
 |---|---|
 | 🚫 Hide Ads | Hides sponsored ads and Google Ads. Also disables Microsoft Clarity analytics. |
 | 🔕 Hide Pur | Hides the Pur ad-free subscription option from the settings menu. |
+| 🔗 Remove Tracking Params | Removes UTM tracking parameters from URLs shared via the in-app share function. |
 
 &nbsp;
 ## How to use
@@ -79,6 +81,7 @@ The goal of this project is to migrate missing ReVanced patches to Morphe and ke
    - **Change package name** *(from the Morphe Patches repository — optional, prevent Google Play from updating)*
    - **Hide Ads** *(this repository)*
    - **Hide Pur** *(this repository)*
+   - **Remove Tracking Params** *(this repository — optional)*
 
 &nbsp;
 ## Contributing

--- a/patches/src/main/kotlin/app/docbt/patched_up/kleinanzeigen/sharetracking/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/docbt/patched_up/kleinanzeigen/sharetracking/Fingerprints.kt
@@ -1,0 +1,12 @@
+package app.docbt.patched_up.kleinanzeigen.sharetracking
+
+import app.morphe.patcher.Fingerprint
+
+// e.h() in Lebk/ui/vip/compose/content/e — builds the share URL for VIP ad pages.
+// Takes (Context, String, String, Z, Z) and returns the share URL string with UTM params.
+// Switches utm_source based on target app: "facebook", "twitter", "whatsapp", "sharesheet" (default).
+// "sharesheet" is the fallback UTM source and is a stable unique string across versions.
+internal object ShareUrlBuilderFingerprint : Fingerprint(
+    strings = listOf("sharesheet"),
+    custom = { _, classDef -> classDef.type == "Lebk/ui/vip/compose/content/e;" },
+)

--- a/patches/src/main/kotlin/app/docbt/patched_up/kleinanzeigen/sharetracking/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/docbt/patched_up/kleinanzeigen/sharetracking/Fingerprints.kt
@@ -2,11 +2,22 @@ package app.docbt.patched_up.kleinanzeigen.sharetracking
 
 import app.morphe.patcher.Fingerprint
 
-// e.h() in Lebk/ui/vip/compose/content/e — builds the share URL for VIP ad pages.
-// Takes (Context, String, String, Z, Z) and returns the share URL string with UTM params.
-// Switches utm_source based on target app: "facebook", "twitter", "whatsapp", "sharesheet" (default).
-// "sharesheet" is the fallback UTM source and is a stable unique string across versions.
+// e.h() — builds the VIP ad share URL, switches utm_source by target app.
+// "sharesheet" is the stable default source string (used for generic share sheet).
 internal object ShareUrlBuilderFingerprint : Fingerprint(
     strings = listOf("sharesheet"),
     custom = { _, classDef -> classDef.type == "Lebk/ui/vip/compose/content/e;" },
+)
+
+// e.i(url, source) — appends UTM params to a URL and returns the result.
+// Called by h() for ad sharing and directly for store sharing.
+// Signature: (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+// Identified by: same class as h(), returns String, takes exactly 2 String parameters.
+internal object ShareUrlParamBuilderFingerprint : Fingerprint(
+    custom = { method, classDef ->
+        classDef.type == "Lebk/ui/vip/compose/content/e;" &&
+        method.returnType == "Ljava/lang/String;" &&
+        method.parameterTypes.size == 2 &&
+        method.parameterTypes.all { it.toString() == "Ljava/lang/String;" }
+    },
 )

--- a/patches/src/main/kotlin/app/docbt/patched_up/kleinanzeigen/sharetracking/RemoveTrackingParamsPatch.kt
+++ b/patches/src/main/kotlin/app/docbt/patched_up/kleinanzeigen/sharetracking/RemoveTrackingParamsPatch.kt
@@ -1,0 +1,59 @@
+package app.docbt.patched_up.kleinanzeigen.sharetracking
+
+import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
+import app.morphe.patcher.patch.AppTarget
+import app.morphe.patcher.patch.Compatibility
+import app.morphe.patcher.patch.bytecodePatch
+import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
+
+private val COMPAT = Compatibility(
+    name = "Kleinanzeigen",
+    packageName = "com.ebay.kleinanzeigen",
+    appIconColor = 0x2EAD33,
+    targets = listOf(
+        AppTarget(version = "2026.14.2"),
+        AppTarget(version = "2026.14.0"),
+    ),
+)
+
+@Suppress("unused")
+val removeTrackingParamsPatch = bytecodePatch(
+    name = "Remove tracking parameters from share URLs",
+    description = "Strips UTM tracking parameters from URLs shared via the in-app share function.",
+) {
+    compatibleWith(COMPAT)
+
+    execute {
+        with(InstructionExtensions) {
+            val method = ShareUrlBuilderFingerprint.method
+            val instructions = method.implementation!!.instructions
+
+            // Find all return-object instructions in reverse order so that inserting
+            // instructions before each one does not shift the indices of later ones.
+            val returnIndices = instructions
+                .withIndex()
+                .filter { (_, instr) -> instr.opcode == Opcode.RETURN_OBJECT }
+                .map { (i, instr) -> i to (instr as OneRegisterInstruction).registerA }
+                .toList()
+                .reversed()
+
+            for ((index, reg) in returnIndices) {
+                // Strip UTM params from the URL before returning.
+                // Uri.parse(url).buildUpon().clearQuery().build().toString()
+                // Each addInstruction(index, ...) inserts at `index`, pushing previous
+                // insertions down — so we add them in reverse order of desired execution.
+                method.addInstruction(index, "move-result-object v$reg")
+                method.addInstruction(index, "invoke-virtual {v$reg}, Landroid/net/Uri;.toString:()Ljava/lang/String;")
+                method.addInstruction(index, "move-result-object v$reg")
+                method.addInstruction(index, "invoke-virtual {v$reg}, Landroid/net/Uri\$Builder;.build:()Landroid/net/Uri;")
+                method.addInstruction(index, "move-result-object v$reg")
+                method.addInstruction(index, "invoke-virtual {v$reg}, Landroid/net/Uri\$Builder;.clearQuery:()Landroid/net/Uri\$Builder;")
+                method.addInstruction(index, "move-result-object v$reg")
+                method.addInstruction(index, "invoke-virtual {v$reg}, Landroid/net/Uri;.buildUpon:()Landroid/net/Uri\$Builder;")
+                method.addInstruction(index, "move-result-object v$reg")
+                method.addInstruction(index, "invoke-static {v$reg}, Landroid/net/Uri;.parse:(Ljava/lang/String;)Landroid/net/Uri;")
+            }
+        }
+    }
+}

--- a/patches/src/main/kotlin/app/docbt/patched_up/kleinanzeigen/sharetracking/RemoveTrackingParamsPatch.kt
+++ b/patches/src/main/kotlin/app/docbt/patched_up/kleinanzeigen/sharetracking/RemoveTrackingParamsPatch.kt
@@ -25,35 +25,33 @@ val removeTrackingParamsPatch = bytecodePatch(
     compatibleWith(COMPAT)
 
     execute {
-        with(InstructionExtensions) {
-            val method = ShareUrlBuilderFingerprint.method
-            val instructions = method.implementation!!.instructions
+        val method = ShareUrlBuilderFingerprint.method
+        val instructions = method.implementation!!.instructions
 
-            // Find all return-object instructions in reverse order so that inserting
-            // instructions before each one does not shift the indices of later ones.
-            val returnIndices = instructions
-                .withIndex()
-                .filter { (_, instr) -> instr.opcode == Opcode.RETURN_OBJECT }
-                .map { (i, instr) -> i to (instr as OneRegisterInstruction).registerA }
-                .toList()
-                .reversed()
+        // Find all return-object instructions in reverse order so that inserting
+        // instructions before each one does not shift the indices of later ones.
+        val returnIndices = instructions
+            .withIndex()
+            .filter { (_, instr) -> instr.opcode == Opcode.RETURN_OBJECT }
+            .map { (i, instr) -> i to (instr as OneRegisterInstruction).registerA }
+            .toList()
+            .reversed()
 
-            for ((index, reg) in returnIndices) {
-                // Strip UTM params from the URL before returning.
-                // Uri.parse(url).buildUpon().clearQuery().build().toString()
-                // Each addInstruction(index, ...) inserts at `index`, pushing previous
-                // insertions down — so we add them in reverse order of desired execution.
-                method.addInstruction(index, "move-result-object v$reg")
-                method.addInstruction(index, "invoke-virtual {v$reg}, Landroid/net/Uri;.toString:()Ljava/lang/String;")
-                method.addInstruction(index, "move-result-object v$reg")
-                method.addInstruction(index, "invoke-virtual {v$reg}, Landroid/net/Uri\$Builder;.build:()Landroid/net/Uri;")
-                method.addInstruction(index, "move-result-object v$reg")
-                method.addInstruction(index, "invoke-virtual {v$reg}, Landroid/net/Uri\$Builder;.clearQuery:()Landroid/net/Uri\$Builder;")
-                method.addInstruction(index, "move-result-object v$reg")
-                method.addInstruction(index, "invoke-virtual {v$reg}, Landroid/net/Uri;.buildUpon:()Landroid/net/Uri\$Builder;")
-                method.addInstruction(index, "move-result-object v$reg")
-                method.addInstruction(index, "invoke-static {v$reg}, Landroid/net/Uri;.parse:(Ljava/lang/String;)Landroid/net/Uri;")
-            }
+        for ((index, reg) in returnIndices) {
+            // Strip UTM params from the URL before returning.
+            // Uri.parse(url).buildUpon().clearQuery().build().toString()
+            // Each addInstruction(index, ...) inserts at `index`, pushing previous
+            // insertions down — so we add them in reverse order of desired execution.
+            method.addInstruction(index, "move-result-object v$reg")
+            method.addInstruction(index, "invoke-virtual {v$reg}, Landroid/net/Uri;.toString:()Ljava/lang/String;")
+            method.addInstruction(index, "move-result-object v$reg")
+            method.addInstruction(index, "invoke-virtual {v$reg}, Landroid/net/Uri\$Builder;.build:()Landroid/net/Uri;")
+            method.addInstruction(index, "move-result-object v$reg")
+            method.addInstruction(index, "invoke-virtual {v$reg}, Landroid/net/Uri\$Builder;.clearQuery:()Landroid/net/Uri\$Builder;")
+            method.addInstruction(index, "move-result-object v$reg")
+            method.addInstruction(index, "invoke-virtual {v$reg}, Landroid/net/Uri;.buildUpon:()Landroid/net/Uri\$Builder;")
+            method.addInstruction(index, "move-result-object v$reg")
+            method.addInstruction(index, "invoke-static {v$reg}, Landroid/net/Uri;.parse:(Ljava/lang/String;)Landroid/net/Uri;")
         }
     }
 }

--- a/patches/src/main/kotlin/app/docbt/patched_up/kleinanzeigen/sharetracking/RemoveTrackingParamsPatch.kt
+++ b/patches/src/main/kotlin/app/docbt/patched_up/kleinanzeigen/sharetracking/RemoveTrackingParamsPatch.kt
@@ -43,15 +43,15 @@ val removeTrackingParamsPatch = bytecodePatch(
             // Each addInstruction(index, ...) inserts at `index`, pushing previous
             // insertions down — so we add them in reverse order of desired execution.
             method.addInstruction(index, "move-result-object v$reg")
-            method.addInstruction(index, "invoke-virtual {v$reg}, Landroid/net/Uri;.toString:()Ljava/lang/String;")
+            method.addInstruction(index, "invoke-virtual {v$reg}, Landroid/net/Uri;->toString:()Ljava/lang/String;")
             method.addInstruction(index, "move-result-object v$reg")
-            method.addInstruction(index, "invoke-virtual {v$reg}, Landroid/net/Uri\$Builder;.build:()Landroid/net/Uri;")
+            method.addInstruction(index, "invoke-virtual {v$reg}, Landroid/net/Uri\$Builder;->build:()Landroid/net/Uri;")
             method.addInstruction(index, "move-result-object v$reg")
-            method.addInstruction(index, "invoke-virtual {v$reg}, Landroid/net/Uri\$Builder;.clearQuery:()Landroid/net/Uri\$Builder;")
+            method.addInstruction(index, "invoke-virtual {v$reg}, Landroid/net/Uri\$Builder;->clearQuery:()Landroid/net/Uri\$Builder;")
             method.addInstruction(index, "move-result-object v$reg")
-            method.addInstruction(index, "invoke-virtual {v$reg}, Landroid/net/Uri;.buildUpon:()Landroid/net/Uri\$Builder;")
+            method.addInstruction(index, "invoke-virtual {v$reg}, Landroid/net/Uri;->buildUpon:()Landroid/net/Uri\$Builder;")
             method.addInstruction(index, "move-result-object v$reg")
-            method.addInstruction(index, "invoke-static {v$reg}, Landroid/net/Uri;.parse:(Ljava/lang/String;)Landroid/net/Uri;")
+            method.addInstruction(index, "invoke-static {v$reg}, Landroid/net/Uri;->parse:(Ljava/lang/String;)Landroid/net/Uri;")
         }
     }
 }

--- a/patches/src/main/kotlin/app/docbt/patched_up/kleinanzeigen/sharetracking/RemoveTrackingParamsPatch.kt
+++ b/patches/src/main/kotlin/app/docbt/patched_up/kleinanzeigen/sharetracking/RemoveTrackingParamsPatch.kt
@@ -4,8 +4,6 @@ import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
 import app.morphe.patcher.patch.AppTarget
 import app.morphe.patcher.patch.Compatibility
 import app.morphe.patcher.patch.bytecodePatch
-import com.android.tools.smali.dexlib2.Opcode
-import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 
 private val COMPAT = Compatibility(
     name = "Kleinanzeigen",
@@ -25,33 +23,10 @@ val removeTrackingParamsPatch = bytecodePatch(
     compatibleWith(COMPAT)
 
     execute {
-        val method = ShareUrlBuilderFingerprint.method
-        val instructions = method.implementation!!.instructions
-
-        // Find all return-object instructions in reverse order so that inserting
-        // instructions before each one does not shift the indices of later ones.
-        val returnIndices = instructions
-            .withIndex()
-            .filter { (_, instr) -> instr.opcode == Opcode.RETURN_OBJECT }
-            .map { (i, instr) -> i to (instr as OneRegisterInstruction).registerA }
-            .toList()
-            .reversed()
-
-        for ((index, reg) in returnIndices) {
-            // Strip UTM params from the URL before returning.
-            // Uri.parse(url).buildUpon().clearQuery().build().toString()
-            // Each addInstruction(index, ...) inserts at `index`, pushing previous
-            // insertions down — so we add them in reverse order of desired execution.
-            method.addInstruction(index, "move-result-object v$reg")
-            method.addInstruction(index, "invoke-virtual {v$reg}, Landroid/net/Uri;->toString:()Ljava/lang/String;")
-            method.addInstruction(index, "move-result-object v$reg")
-            method.addInstruction(index, "invoke-virtual {v$reg}, Landroid/net/Uri\$Builder;->build:()Landroid/net/Uri;")
-            method.addInstruction(index, "move-result-object v$reg")
-            method.addInstruction(index, "invoke-virtual {v$reg}, Landroid/net/Uri\$Builder;->clearQuery:()Landroid/net/Uri\$Builder;")
-            method.addInstruction(index, "move-result-object v$reg")
-            method.addInstruction(index, "invoke-virtual {v$reg}, Landroid/net/Uri;->buildUpon:()Landroid/net/Uri\$Builder;")
-            method.addInstruction(index, "move-result-object v$reg")
-            method.addInstruction(index, "invoke-static {v$reg}, Landroid/net/Uri;->parse:(Ljava/lang/String;)Landroid/net/Uri;")
-        }
+        // e.i(url, source) appends UTM params to the URL and returns it.
+        // Returning p0 (the first argument = the original URL) immediately
+        // skips the UTM construction entirely.
+        // This covers both ad sharing (called from e.h()) and store sharing (direct call).
+        ShareUrlParamBuilderFingerprint.method.addInstruction(0, "return-object p0")
     }
 }


### PR DESCRIPTION
## Summary

- Adds new patch **Remove Tracking Params** for Kleinanzeigen
- Patches `e.i(url, source)` in `Lebk/ui/vip/compose/content/e` to return the URL unmodified (skipping UTM param construction)
- Covers both ad sharing (via `e.h()`) and store sharing (direct call to `e.i()`)
- Updates README with new patch entry

## Test plan

- [ ] Apply patch to Kleinanzeigen 2026.14.2
- [ ] Tap share on an ad listing
- [ ] Verify shared URL has no `?utm_source=...` parameters