### PR TITLE
fix(googlenews): spoof the real Google News signing cert (fresh-install sign-in loop)

### DIFF
--- a/patches/src/main/kotlin/app/docbt/patched_up/googlenews/gms/GmsCoreSupportPatch.kt
+++ b/patches/src/main/kotlin/app/docbt/patched_up/googlenews/gms/GmsCoreSupportPatch.kt
@@ -30,8 +30,12 @@ private val COMPAT = Compatibility(
     ),
 )
 
-// SHA-1 of Google's release signing certificate (shared across Google apps).
-private const val SPOOFED_PACKAGE_SIGNATURE = "24bb24c05e47e0aefa68a58a766179d9b613a600"
+// SHA-1 of the certificate that actually signs Google News (com.google.android.apps.magazines):
+// O=Google Inc., CN=Android — the Google "Android" master release cert. Verified against the
+// v2 APK signing block of the shipped APK. MicroG RE reports this signature to Google's auth
+// backend so a renamed install keeps the original package identity; a wrong value makes the
+// backend reject the token grant after login (fresh-install sign-in loop).
+private const val SPOOFED_PACKAGE_SIGNATURE = "38918a453d07199354f8b19af05ec6562ced5788"
 
 private val gmsCoreSupportResourcePatch = resourcePatch {
     execute {
@@ -111,13 +115,7 @@ private val ACTIONS = setOf(
     "com.google.android.gms.asterism.service.START",
     "com.google.android.gms.audiomodem.service.AudioModemService.START",
     "com.google.android.gms.audit.service.START",
-    // NOTE: com.google.android.gms.auth.aang.events.services.START is deliberately
-    // NOT transformed. The AANG events service (bound via getStartServiceAction() in
-    // the aang auth client) has no counterpart in MicroG RE, so rewriting it to
-    // "app.revanced.*" points the bind at a non-existent service and breaks the
-    // fresh-install account-add return flow (sign-in loops after login). Leaving it
-    // as "com.google.*" restores the behaviour of the first working releases.
-    // See regression from commit 7342da2.
+    "com.google.android.gms.auth.aang.events.services.START",
     "com.google.android.gms.auth.account.authapi.START",
     "com.google.android.gms.auth.account.authenticator.auto.service.START",
     "com.google.android.gms.auth.account.authenticator.chromeos.START",


### PR DESCRIPTION
## Root cause (directly verifiable — not a control-flow hypothesis)

Der GmsCore-Patch spooft `SPOOFED_PACKAGE_SIGNATURE = 24bb24c05e47e0aefa68a58a766179d9b613a600`. Das ist **nicht** das Zertifikat, mit dem Google News signiert ist.

Aus dem **v2-Signaturblock der ausgelieferten APK** extrahiert:
- Subject: `O=Google Inc., CN=Android` (Google-„Android"-Master-Cert, 2008)
- **Cert SHA-1: `38918a453d07199354f8b19af05ec6562ced5788`**

Der alte Wert entspricht **keiner** Darstellung des echten Certs (Cert-SHA-1, MD5, Pubkey-SHA-1) — er war schlicht falsch, vermutlich aus einem anderen Patch kopiert.

**Warum es das Symptom erklärt:** MicroG RE meldet diese Signatur an Googles Auth-Backend, damit die umbenannte Installation die Original-Identität behält. Bei falscher Signatur lehnt das Backend den Token-Grant **nach** erfolgreichem Login ab → Rückmeldung kommt nie zurück → Login-Schleife. Nur bei Fresh-Install, da ein Update den gecachten Token wiederverwendet.

Enthält außerdem das **Zurücksetzen der aang-Events-Änderung** (deren Prämisse durch diesen Befund widerlegt ist), damit die Signatur die einzige getestete Variable ist.

## ⚠️ Bitte zuerst testen — kein Release bis bestätigt
- [ ] MPP aus dem PR-Build-Artifact (`patches-pr`) laden
- [ ] **Frische** Neuinstallation GN v5.163 patchen (alle 3 Patches)
- [ ] Google-Login → **Rückmeldung sollte jetzt durchlaufen, keine Schleife**

Ich kann den Login-Flow hier nicht selbst ausführen (kein Gerät/MicroG). Der Wert ist aber nachweislich das echte Signing-Cert der App — im Gegensatz zum alten falschen Wert. Ob es die Schleife final behebt, zeigt dein Fresh-Install-Test.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J6PqqntTLoAeRvUnLqj659)_