### PR TITLE
fix: support Kleinanzeigen 2026.27.0 in hide ads and hide pur

### DIFF
--- a/patches/src/main/kotlin/app/docbt/patched_up/kleinanzeigen/ads/HideAdsPatch.kt
+++ b/patches/src/main/kotlin/app/docbt/patched_up/kleinanzeigen/ads/HideAdsPatch.kt
@@ -10,6 +10,7 @@ private val COMPAT = Compatibility(
     packageName = "com.ebay.kleinanzeigen",
     appIconColor = 0x2EAD33,
     targets = listOf(
+        AppTarget(version = "2026.32.0"),
         AppTarget(version = "2026.27.0"),
         AppTarget(version = "2026.16.1"),
         AppTarget(version = "2026.14.2"),

--- a/patches/src/main/kotlin/app/docbt/patched_up/kleinanzeigen/ads/HideAdsPatch.kt
+++ b/patches/src/main/kotlin/app/docbt/patched_up/kleinanzeigen/ads/HideAdsPatch.kt
@@ -10,6 +10,7 @@ private val COMPAT = Compatibility(
     packageName = "com.ebay.kleinanzeigen",
     appIconColor = 0x2EAD33,
     targets = listOf(
+        AppTarget(version = "2026.27.0"),
         AppTarget(version = "2026.16.1"),
         AppTarget(version = "2026.14.2"),
         AppTarget(version = "2026.14.0"),

--- a/patches/src/main/kotlin/app/docbt/patched_up/kleinanzeigen/hidepur/HidePurPatch.kt
+++ b/patches/src/main/kotlin/app/docbt/patched_up/kleinanzeigen/hidepur/HidePurPatch.kt
@@ -12,6 +12,7 @@ private val COMPAT = Compatibility(
     packageName = "com.ebay.kleinanzeigen",
     appIconColor = 0x2EAD33,
     targets = listOf(
+        AppTarget(version = "2026.32.0"),
         AppTarget(version = "2026.27.0"),
         AppTarget(version = "2026.16.1"),
         AppTarget(version = "2026.14.2"),

--- a/patches/src/main/kotlin/app/docbt/patched_up/kleinanzeigen/hidepur/HidePurPatch.kt
+++ b/patches/src/main/kotlin/app/docbt/patched_up/kleinanzeigen/hidepur/HidePurPatch.kt
@@ -12,6 +12,7 @@ private val COMPAT = Compatibility(
     packageName = "com.ebay.kleinanzeigen",
     appIconColor = 0x2EAD33,
     targets = listOf(
+        AppTarget(version = "2026.27.0"),
         AppTarget(version = "2026.16.1"),
         AppTarget(version = "2026.14.2"),
         AppTarget(version = "2026.14.0"),
@@ -30,6 +31,8 @@ val hidePurPatch = bytecodePatch(
             // setupSections() (2026.9.0) / q() (2026.12.0) in SettingsAndHelpFragment:
             // p7 = showAdFreeSubscription. The single IF_EQZ p7 sends to GONE when false,
             // VISIBLE when true. Forcing vReg = 0 before IF_EQZ always hides the Pur entry.
+            // const/4 only encodes registers v0-v15; since 2026.27.0 the param sits in
+            // v21 (p7), so const/16 is required for register-agnostic behavior.
             val method = SetupSectionsPurFingerprint.method
             var ifEqzIndex = -1
             var showAdFreeReg = -1
@@ -41,7 +44,7 @@ val hidePurPatch = bytecodePatch(
                 }
             }
             check(ifEqzIndex != -1) { "IF_EQZ not found in setupSections/q" }
-            method.addInstruction(ifEqzIndex, "const/4 v$showAdFreeReg, 0x0")
+            method.addInstruction(ifEqzIndex, "const/16 v$showAdFreeReg, 0x0")
         }
     }
 }

--- a/versions.json
+++ b/versions.json
@@ -1,4 +1,4 @@
 {
   "googleNews": "5.163.0.947799485",
-  "kleinanzeigen": "2026.16.1"
+  "kleinanzeigen": "2026.32.0"
 }


### PR DESCRIPTION
Kleinanzeigen 2026.27.0 support

"Hide Pur" crashed on the current app version (2026.27.0):
const/4 can't encode register v21 (the Pur flag moved to a high
register), producing an invalid smali string -> patching failed in
Morphe Manager. Switched to const/16, which is register-agnostic.

- Hide Pur: const/4 -> const/16 for the injected flag
- Both patches: added 2026.27.0 to compat targets

Verified:
- Fingerprints still match on 2026.27.0 (KEY_LIBERTY_REFRESH_INTERVAL
  string present; SettingsAndHelpFragment type unchanged)
- Fixed instruction confirmed applied in Manager on 2026.27.0

Note: "Remove tracking parameters" fingerprints an obfuscated class
(Lebk/ui/vip/compose/content/e;) that isn't stable across versions,
so it stays on the older targets for now - Manager auto-skips it on
2026.27.0.